### PR TITLE
#18 Add nicer error message if module cannot be imported

### DIFF
--- a/src/slotscheck/common.py
+++ b/src/slotscheck/common.py
@@ -24,8 +24,15 @@ def cli(modulename: str, verbose: bool) -> None:
         stream=sys.stderr,
         level=logging.INFO if verbose else logging.ERROR,
     )
+
+    try:
+        module = importlib.import_module(modulename)
+    except ModuleNotFoundError:
+        print(f"ERROR: could not import module '{modulename}'")
+        return
+
     classes = _groupby(
-        set(walk_classes(importlib.import_module(modulename))),
+        set(walk_classes(module)),
         key=slot_status,
     )
     broken_slots = [

--- a/src/slotscheck/common.py
+++ b/src/slotscheck/common.py
@@ -29,7 +29,7 @@ def cli(modulename: str, verbose: bool) -> None:
         module = importlib.import_module(modulename)
     except ModuleNotFoundError:
         print(f"ERROR: could not import module '{modulename}'")
-        return
+        exit(1)
 
     classes = _groupby(
         set(walk_classes(module)),


### PR DESCRIPTION
Fixes #18 by adding a nicer looking error message if a base module cannot be imported when calling `slotscheck [modulename]`.