### PR TITLE
Improve pure-python check using immutable type flag

### DIFF
--- a/src/slotscheck/checks.py
+++ b/src/slotscheck/checks.py
@@ -48,12 +48,17 @@ def has_duplicate_slots(c: type) -> bool:
 # If the active Python interpreter is the official CPython interpreter,
 # prefer a more reliable CPython-specific solution guaranteed to succeed.
 if platform.python_implementation() == "CPython":
-    # Magic number defined by the Python codebase at "Include/object.h".
+    # Magic numbers defined by the Python codebase at "Include/object.h".
+    Py_TPFLAGS_IMMUTABLETYPE = 1 << 8
     Py_TPFLAGS_HEAPTYPE = 1 << 9
 
     def is_pure_python(cls: type) -> bool:
         "Whether the class is pure-Python or C-based"
-        return bool(cls.__flags__ & Py_TPFLAGS_HEAPTYPE)
+        # Starting with CPython 3.10, `Py_TPFLAGS_HEAPTYPE` should no longer
+        # be relied on, and `!Py_TPFLAGS_IMMUTABLETYPE` should be used instead.
+        return bool(cls.__flags__ & Py_TPFLAGS_HEAPTYPE) and not bool(
+            cls.__flags__ & Py_TPFLAGS_IMMUTABLETYPE
+        )
 
 
 # Else, fallback to a CPython-agnostic solution typically but *NOT*

--- a/src/slotscheck/checks.py
+++ b/src/slotscheck/checks.py
@@ -59,7 +59,7 @@ if platform.python_implementation() == "CPython":
 
         def is_pure_python(cls: type) -> bool:
             "Whether the class is pure-Python or C-based"
-            return not bool(cls.__flags__ & Py_TPFLAGS_IMMUTABLETYPE)
+            return not (cls.__flags__ & Py_TPFLAGS_IMMUTABLETYPE)
 
     else:
 

--- a/src/slotscheck/checks.py
+++ b/src/slotscheck/checks.py
@@ -1,5 +1,6 @@
 "Slots-related checks and inspection tools"
 import platform
+import sys
 from typing import Collection, Iterator, Optional
 
 
@@ -52,13 +53,19 @@ if platform.python_implementation() == "CPython":
     Py_TPFLAGS_IMMUTABLETYPE = 1 << 8
     Py_TPFLAGS_HEAPTYPE = 1 << 9
 
-    def is_pure_python(cls: type) -> bool:
-        "Whether the class is pure-Python or C-based"
-        # Starting with CPython 3.10, `Py_TPFLAGS_HEAPTYPE` should no longer
-        # be relied on, and `!Py_TPFLAGS_IMMUTABLETYPE` should be used instead.
-        return bool(cls.__flags__ & Py_TPFLAGS_HEAPTYPE) and not bool(
-            cls.__flags__ & Py_TPFLAGS_IMMUTABLETYPE
-        )
+    # Starting with CPython 3.10, `Py_TPFLAGS_HEAPTYPE` should no longer
+    # be relied on, and `!Py_TPFLAGS_IMMUTABLETYPE` should be used instead.
+    if sys.version_info >= (3, 10):  # pragma: no cover
+
+        def is_pure_python(cls: type) -> bool:
+            "Whether the class is pure-Python or C-based"
+            return not bool(cls.__flags__ & Py_TPFLAGS_IMMUTABLETYPE)
+
+    else:
+
+        def is_pure_python(cls: type) -> bool:
+            "Whether the class is pure-Python or C-based"
+            return bool(cls.__flags__ & Py_TPFLAGS_HEAPTYPE)
 
 
 # Else, fallback to a CPython-agnostic solution typically but *NOT*

--- a/tests/src/test_checks.py
+++ b/tests/src/test_checks.py
@@ -1,3 +1,4 @@
+from array import array
 from datetime import date
 from decimal import Decimal
 from enum import Enum
@@ -51,10 +52,14 @@ class OneStringSlot(HasSlots):
     __slots__ = "baz"
 
 
+class ArrayInherit(array):
+    __slots__ = ()
+
+
 class TestHasSlots:
     @pytest.mark.parametrize(
         "klass",
-        [type, dict, date, float, Decimal, Element],
+        [type, dict, date, float, Decimal, Element, array],
     )
     def test_not_purepython(self, klass):
         assert has_slots(klass)
@@ -68,6 +73,7 @@ class TestHasSlots:
             BadInherit,
             BadOverlaps,
             OneStringSlot,
+            ArrayInherit,
         ],
     )
     def test_slots(self, klass):


### PR DESCRIPTION
# Description

As per the [3.10 changelog](https://docs.python.org/3/whatsnew/3.10.html?highlight=py_tpflags_immutabletype#porting-to-python-3-10-1), the `is_pure_python` check in CPython 3.10 should no longer rely on `Py_TPFLAGS_HEAPTYPE`, and instead check for `!Py_TPFLAGS_IMMUTABLETYPE`.

This modifies the `is_pure_python` check to look for both flags, which should hopefully preserve backward compatibility with older versions. 

Resolves #92, took me a while to get around to fixing this :sweat_smile:.

# Before merge

- [x] ``tox`` runs successfully
- [ ] Docs updated

# Before release (if applicable)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in pre-commit hook example
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Published
