### PR TITLE
Fix Protocol imports on >=3.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.16.3 (2023-01-03)
+-------------------
+
+- Fix broken ``Protocol`` import due to absent ``typing_extensions``
+  on Python <3.10.
+
 0.16.2 (2022-12-29)
 -------------------
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -18,7 +18,7 @@ Use the following configuration:
 
    repos:
    - repo: https://github.com/ariebovenberg/slotscheck
-     rev: v0.16.2
+     rev: v0.16.3
      hooks:
      - id: slotscheck
        # If your Python files are not importable from the project root,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slotscheck"
-version = "0.16.2"
+version = "0.16.3"
 description = "Ensure your __slots__ are working properly."
 authors = ["Arie Bovenberg <a.c.bovenberg@gmail.com>"]
 license = "MIT"

--- a/src/slotscheck/cli.py
+++ b/src/slotscheck/cli.py
@@ -54,7 +54,7 @@ from .discovery import (
 try:
     from typing import Protocol
 except ImportError:  # pragma: no cover
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # type: ignore[assignment]
 
 
 @click.command("slotscheck")

--- a/src/slotscheck/cli.py
+++ b/src/slotscheck/cli.py
@@ -19,7 +19,6 @@ from typing import (
 )
 
 import click
-from typing_extensions import Protocol
 
 from . import config
 from .checks import (
@@ -51,6 +50,11 @@ from .discovery import (
     module_tree,
     walk_classes,
 )
+
+try:
+    from typing import Protocol
+except ImportError:  # pragma: no cover
+    from typing_extensions import Protocol
 
 
 @click.command("slotscheck")

--- a/tests/examples/module_not_ok/foo.py
+++ b/tests/examples/module_not_ok/foo.py
@@ -1,4 +1,8 @@
-from typing_extensions import Protocol
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol
 
 
 class A:


### PR DESCRIPTION
# Description

Since typing_extensions is only required on >3.10, attempts to run the latest release on <=3.10 fail if typing_extensions hasn't been installed into the target environment.

Protocol was added to the std `typing` module in 3.8 so this should only ever need to fallback to typing_extensions for Protocol on 3.7 and some 3.8 alpha releases.

I don't know why your CI is installing typing_extensions before running tests on 3.10 and 3.11.

# Before merge

- [] ``tox`` runs successfully
- [] Docs updated

# Before release (if applicable)

- [ ] Version updated in ``pyproject.toml``
- [ ] Version updated in pre-commit hook example
- [ ] Version updated in changelog
- [ ] Branch merged
- [ ] Tag created and pushed
- [ ] Published
