### PR TITLE
Fix discovery of modules in namespace packages

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -51,11 +51,3 @@ Use the following configuration:
        # This requires `slotscheck` to be installed in that environment.
        #
        # language: system
-
-
-Namespace packages
-------------------
-
-Namespace packages come in `different flavors <https://packaging.python.org/en/latest/guides/packaging-namespace-packages/>`_.
-When using the ``-m/--module`` flag in the CLI, all these flavors are supported.
-When specifying file paths, *native* namespace packages are not supported.

--- a/docs/discovery.rst
+++ b/docs/discovery.rst
@@ -9,7 +9,7 @@ However, there are some complications that you may need to be aware of.
 
    You should generally be fine if you follow these rules:
 
-   - To check files in your current directory,
+   - To check files in your current directory, or subdirectories of it,
      you should run slotscheck as ``python -m slotscheck``.
    - To check files elsewhere, you may need to set the ``$PYTHONPATH``
      environment variable.

--- a/src/slotscheck/cli.py
+++ b/src/slotscheck/cli.py
@@ -42,6 +42,7 @@ from .common import (
 from .discovery import (
     AbsPath,
     FailedImport,
+    FileNotInSysPathError,
     ModuleLocated,
     ModuleName,
     ModuleTree,
@@ -162,9 +163,9 @@ def root(
 
     try:
         classes, modules = _collect(files, module, conf)
-    except ModuleNotFoundError as e:
+    except (ModuleNotFoundError, FileNotInSysPathError) as e:
         print(
-            f"ERROR: Module '{e.name}' not found.\n\n"
+            f"ERROR: {e}.\n\n"
             "See slotscheck.rtfd.io/en/latest/discovery.html\n"
             "for help resolving common import problems."
         )

--- a/src/slotscheck/discovery.py
+++ b/src/slotscheck/discovery.py
@@ -165,7 +165,7 @@ def module_tree(
     except BaseException as e:
         return FailedImport(module, e)
     if spec is None:
-        raise ModuleNotFoundError(f"No module named '{module}'", name=module)
+        raise ModuleNotFoundError(f"No module named {module!r}", name=module)
     *namespaces, name = module.split(".")
     location = Path(spec.origin) if spec.has_location and spec.origin else None
     tree: ModuleTree
@@ -292,6 +292,12 @@ class ModuleLocated(NamedTuple):
     expected_location: Optional[AbsPath]
 
 
+class FileNotInSysPathError(Exception):
+    def __init__(self, file: Path) -> None:
+        super().__init__(f"File {str(file)!r} is not in PYTHONPATH")
+        self.file = file
+
+
 def _is_module(p: AbsPath) -> bool:
     return (p.is_file() and p.suffixes == [".py"]) or _is_package(p)
 
@@ -308,7 +314,7 @@ def _module_parents(
         if pp in sys_path:
             return
         yield pp
-    raise ModuleNotFoundError(f"No module named '{p.stem}'", name=p.stem)
+    raise FileNotInSysPathError(p)
 
 
 def _find_modules(

--- a/src/slotscheck/discovery.py
+++ b/src/slotscheck/discovery.py
@@ -308,7 +308,7 @@ def _module_parents(
         if pp in sys_path:
             return
         yield pp
-    raise ValueError(f"File {p} is outside of PYTHONPATH ({sys.path})")
+    raise ModuleNotFoundError(f"No module named '{p.stem}'", name=p.stem)
 
 
 def _find_modules(

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -13,9 +13,9 @@ EXAMPLE_NAMES = tuple(
 @pytest.fixture(scope="session", autouse=True)
 def add_pypath() -> Iterator[None]:
     "Add example modules to the python path"
-    sys.path.insert(0, str(EXAMPLES_DIR))
+    sys.path[:0] = [str(EXAMPLES_DIR), str(EXAMPLES_DIR / "other")]
     yield
-    sys.path.remove(str(EXAMPLES_DIR))
+    del sys.path[:2]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/src/test_cli.py
+++ b/tests/src/test_cli.py
@@ -39,6 +39,19 @@ def test_module_doesnt_exist(runner: CliRunner):
     )
 
 
+def test_python_file_not_in_sys_path(runner: CliRunner, tmpdir):
+    file = tmpdir / "foo.py"
+    file.write_text('print("Hello, world!")', encoding="utf-8")
+    result = runner.invoke(cli, [str(file)])
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert result.output == (
+        "ERROR: Module 'foo' not found.\n\n"
+        "See slotscheck.rtfd.io/en/latest/discovery.html\n"
+        "for help resolving common import problems.\n"
+    )
+
+
 def test_module_is_uninspectable(runner: CliRunner):
     result = runner.invoke(cli, ["-m", "broken.submodule"])
     assert result.exit_code == 1

--- a/tests/src/test_cli.py
+++ b/tests/src/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import re
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -33,22 +34,23 @@ def test_module_doesnt_exist(runner: CliRunner):
     assert result.exit_code == 1
     assert isinstance(result.exception, SystemExit)
     assert result.output == (
-        "ERROR: Module 'foo' not found.\n\n"
+        "ERROR: No module named 'foo'.\n\n"
         "See slotscheck.rtfd.io/en/latest/discovery.html\n"
         "for help resolving common import problems.\n"
     )
 
 
-def test_python_file_not_in_sys_path(runner: CliRunner, tmpdir):
-    file = tmpdir / "foo.py"
+def test_python_file_not_in_sys_path(runner: CliRunner, tmp_path: Path):
+    file = tmp_path / "foo.py"
     file.write_text('print("Hello, world!")', encoding="utf-8")
     result = runner.invoke(cli, [str(file)])
     assert result.exit_code == 1
     assert isinstance(result.exception, SystemExit)
-    assert result.output == (
-        "ERROR: Module 'foo' not found.\n\n"
+    assert re.fullmatch(
+        "ERROR: File '.*/foo.py' is not in PYTHONPATH.\n\n"
         "See slotscheck.rtfd.io/en/latest/discovery.html\n"
-        "for help resolving common import problems.\n"
+        "for help resolving common import problems.\n",
+        result.output,
     )
 
 

--- a/tests/src/test_cli.py
+++ b/tests/src/test_cli.py
@@ -157,6 +157,16 @@ def test_multiple_modules(runner: CliRunner):
     assert result.output == "All OK!\nScanned 11 module(s), 70 class(es).\n"
 
 
+def test_implicitly_namespaced_path(runner: CliRunner):
+    result = runner.invoke(
+        cli,
+        [str(EXAMPLES_DIR / "implicitly_namespaced")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert result.output == "All OK!\nScanned 7 module(s), 1 class(es).\n"
+
+
 def test_multiple_paths(runner: CliRunner):
     result = runner.invoke(
         cli,

--- a/tests/src/test_discovery.py
+++ b/tests/src/test_discovery.py
@@ -370,13 +370,13 @@ class TestFindModules:
     def test_given_python_file(self):
         location = EXAMPLES_DIR / "files/subdir/myfile.py"
         result = list(find_modules(location))
-        assert result == [ModuleLocated("myfile", location)]
+        assert result == [ModuleLocated("files.subdir.myfile", location)]
 
     def test_given_python_root_module(self):
         location = EXAMPLES_DIR / "files/subdir/some_module/"
         result = list(find_modules(location))
         assert result == [
-            ModuleLocated("some_module", location / "__init__.py")
+            ModuleLocated("files.subdir.some_module", location / "__init__.py")
         ]
 
     def test_given_dir_containing_python_files(self):
@@ -384,10 +384,12 @@ class TestFindModules:
         result = list(find_modules(location))
         assert len(result) == 4
         assert set(result) == {
-            ModuleLocated("bla", location / "bla.py"),
-            ModuleLocated("foo", location / "foo.py"),
-            ModuleLocated("foo", location / "sub/foo.py"),
-            ModuleLocated("mymodule", location / "mymodule/__init__.py"),
+            ModuleLocated("files.my_scripts.bla", location / "bla.py"),
+            ModuleLocated("files.my_scripts.foo", location / "foo.py"),
+            ModuleLocated("files.my_scripts.sub.foo", location / "sub/foo.py"),
+            ModuleLocated(
+                "files.my_scripts.mymodule", location / "mymodule/__init__.py"
+            ),
         }
 
     def test_given_file_within_module(self):
@@ -395,7 +397,7 @@ class TestFindModules:
         result = list(find_modules(location))
         assert result == [
             ModuleLocated(
-                "some_module.sub.foo",
+                "files.subdir.some_module.sub.foo",
                 EXAMPLES_DIR / "files/subdir/some_module/sub/foo.py",
             )
         ]
@@ -404,13 +406,17 @@ class TestFindModules:
         location = EXAMPLES_DIR / "files/subdir/some_module/sub"
         result = list(find_modules(location))
         assert result == [
-            ModuleLocated("some_module.sub", location / "__init__.py")
+            ModuleLocated(
+                "files.subdir.some_module.sub", location / "__init__.py"
+            )
         ]
 
     def test_given_init_py(self):
         location = EXAMPLES_DIR / "files/subdir/some_module/sub/__init__.py"
         result = list(find_modules(location))
-        assert result == [ModuleLocated("some_module.sub", location)]
+        assert result == [
+            ModuleLocated("files.subdir.some_module.sub", location)
+        ]
 
 
 class TestConsolidate:

--- a/tests/src/test_discovery.py
+++ b/tests/src/test_discovery.py
@@ -421,7 +421,7 @@ class TestFindModules:
     def test_given_file_not_in_sys_path(self, tmp_path):
         location = tmp_path / "foo.py"
         location.touch()
-        with pytest.raises(ValueError, match="is outside of PYTHONPATH"):
+        with pytest.raises(ModuleNotFoundError, match="foo"):
             list(find_modules(location))
 
 

--- a/tests/src/test_discovery.py
+++ b/tests/src/test_discovery.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import FrozenSet, List, TypeVar
 from unittest import mock
 
@@ -5,6 +6,7 @@ import pytest
 
 from slotscheck.discovery import (
     FailedImport,
+    FileNotInSysPathError,
     Module,
     ModuleLocated,
     ModuleTree,
@@ -418,10 +420,10 @@ class TestFindModules:
             ModuleLocated("files.subdir.some_module.sub", location)
         ]
 
-    def test_given_file_not_in_sys_path(self, tmp_path):
+    def test_given_file_not_in_sys_path(self, tmp_path: Path):
         location = tmp_path / "foo.py"
         location.touch()
-        with pytest.raises(ModuleNotFoundError, match="foo"):
+        with pytest.raises(FileNotInSysPathError, match=r"foo\.py"):
             list(find_modules(location))
 
 

--- a/tests/src/test_discovery.py
+++ b/tests/src/test_discovery.py
@@ -418,6 +418,12 @@ class TestFindModules:
             ModuleLocated("files.subdir.some_module.sub", location)
         ]
 
+    def test_given_file_not_in_sys_path(self, tmp_path):
+        location = tmp_path / "foo.py"
+        location.touch()
+        with pytest.raises(ValueError, match="is outside of PYTHONPATH"):
+            list(find_modules(location))
+
 
 class TestConsolidate:
     def test_empty(self):


### PR DESCRIPTION
Instead of relying on `__init__.py` files, stop at the first parent directory that is in `sys.path`. This gives the shortest module name under which the file can really be imported. (Unless there are name conflicts in `sys.path`, which is arguably a misconfiguration; this is caught by the location check in `module_tree`.)
